### PR TITLE
Fixes missing ~ in path causing code directory to not be built

### DIFF
--- a/generators/CoreCLRStatefulActor/index.js
+++ b/generators/CoreCLRStatefulActor/index.js
@@ -373,7 +373,7 @@ var ClassGenerator = generators.Base.extend({
           \ndotnet build %~dp0\\..\\'+interfaceProject+' -v normal\n \n \
           \ndotnet restore %~dp0\\..\\' + serviceProject+ ' -s https://api.nuget.org/v3/index.json \
           \ndotnet build %~dp0\\..\\'+serviceProject+ ' -v normal\
-          \ndotnet publish %~dp0\\..\\'+serviceProject+' -o %dp0\\..\\'+codePath+'\n\n\
+          \ndotnet publish %~dp0\\..\\'+serviceProject+' -o %~dp0\\..\\'+codePath+'\n\n\
           \ndotnet restore %~dp0\\..\\'+testProject+' -s https://api.nuget.org/v3/index.json \
           \ndotnet build %~dp0\\..\\'+testProject+' -v normal\
           \nfor %%F in ("'+testProject+'") do cd %%~dpF\


### PR DESCRIPTION
Creating a second Actor Service would generate incorrect build.cmd code which causes the Code directory to not be built for the second project.